### PR TITLE
Refactor onboarding flow for backend readiness

### DIFF
--- a/lib/features/Onboarding/data/onboarding_repository.dart
+++ b/lib/features/Onboarding/data/onboarding_repository.dart
@@ -1,0 +1,63 @@
+import '../domain/onboarding_models.dart';
+
+class OnboardingException implements Exception {
+  OnboardingException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+abstract class OnboardingRepository {
+  Future<void> requestOtp(SignUpPayload payload);
+  Future<void> verifyOtp({required String phone, required String otp});
+  Future<void> submitProfile({required String phone, required ProfileInfo profile});
+  Future<void> setPassword({required String phone, required String password});
+  Future<void> finalize(OnboardingFormData data);
+}
+
+class MockOnboardingRepository implements OnboardingRepository {
+  @override
+  Future<void> requestOtp(SignUpPayload payload) async {
+    await Future.delayed(const Duration(milliseconds: 600));
+    if (payload.phoneNumber.endsWith('000')) {
+      throw OnboardingException('Số điện thoại đã tồn tại trong hệ thống');
+    }
+  }
+
+  @override
+  Future<void> verifyOtp({required String phone, required String otp}) async {
+    await Future.delayed(const Duration(milliseconds: 400));
+    if (otp != '123456') {
+      throw OnboardingException('Mã OTP không chính xác');
+    }
+  }
+
+  @override
+  Future<void> submitProfile({
+    required String phone,
+    required ProfileInfo profile,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 400));
+  }
+
+  @override
+  Future<void> setPassword({
+    required String phone,
+    required String password,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 400));
+    if (password.length < 8) {
+      throw OnboardingException('Mật khẩu chưa đáp ứng độ dài tối thiểu');
+    }
+  }
+
+  @override
+  Future<void> finalize(OnboardingFormData data) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    if (data.pin == null || data.pin!.length != 6) {
+      throw OnboardingException('Mã PIN không hợp lệ');
+    }
+  }
+}

--- a/lib/features/Onboarding/data/onboarding_repository.dart
+++ b/lib/features/Onboarding/data/onboarding_repository.dart
@@ -1,14 +1,5 @@
 import '../domain/onboarding_models.dart';
 
-class OnboardingException implements Exception {
-  OnboardingException(this.message);
-
-  final String message;
-
-  @override
-  String toString() => message;
-}
-
 abstract class OnboardingRepository {
   Future<void> requestOtp(SignUpPayload payload);
   Future<void> verifyOtp({required String phone, required String otp});

--- a/lib/features/Onboarding/domain/onboarding_models.dart
+++ b/lib/features/Onboarding/domain/onboarding_models.dart
@@ -1,5 +1,14 @@
 import 'package:equatable/equatable.dart';
 
+class OnboardingException implements Exception {
+  OnboardingException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 /// Thông tin người dùng nhập ở bước đăng ký ban đầu.
 class SignUpPayload extends Equatable {
   const SignUpPayload({

--- a/lib/features/Onboarding/domain/onboarding_models.dart
+++ b/lib/features/Onboarding/domain/onboarding_models.dart
@@ -1,0 +1,129 @@
+import 'package:equatable/equatable.dart';
+
+/// Thông tin người dùng nhập ở bước đăng ký ban đầu.
+class SignUpPayload extends Equatable {
+  const SignUpPayload({
+    required this.citizenId,
+    required this.phoneNumber,
+    this.email,
+    required this.fullName,
+  });
+
+  final String citizenId;
+  final String phoneNumber;
+  final String? email;
+  final String fullName;
+
+  SignUpPayload copyWith({
+    String? citizenId,
+    String? phoneNumber,
+    String? email,
+    String? fullName,
+  }) {
+    return SignUpPayload(
+      citizenId: citizenId ?? this.citizenId,
+      phoneNumber: phoneNumber ?? this.phoneNumber,
+      email: email ?? this.email,
+      fullName: fullName ?? this.fullName,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'citizen_id': citizenId,
+      'phone_number': phoneNumber,
+      'email': email,
+      'full_name': fullName,
+    }..removeWhere((key, value) => value == null);
+  }
+
+  @override
+  List<Object?> get props => [citizenId, phoneNumber, email, fullName];
+}
+
+/// Thông tin hồ sơ cá nhân thu thập ở bước tiếp theo.
+class ProfileInfo extends Equatable {
+  const ProfileInfo({
+    required this.birthDate,
+    required this.gender,
+    required this.major,
+    required this.address,
+  });
+
+  final DateTime birthDate;
+  final String gender;
+  final String major;
+  final String address;
+
+  ProfileInfo copyWith({
+    DateTime? birthDate,
+    String? gender,
+    String? major,
+    String? address,
+  }) {
+    return ProfileInfo(
+      birthDate: birthDate ?? this.birthDate,
+      gender: gender ?? this.gender,
+      major: major ?? this.major,
+      address: address ?? this.address,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'birth_date': birthDate.toIso8601String(),
+      'gender': gender,
+      'major': major,
+      'address': address,
+    };
+  }
+
+  @override
+  List<Object?> get props => [birthDate, gender, major, address];
+}
+
+/// Tổng hợp dữ liệu của toàn bộ quy trình onboarding.
+class OnboardingFormData extends Equatable {
+  const OnboardingFormData({
+    this.signUp,
+    this.otpCode,
+    this.profile,
+    this.password,
+    this.pin,
+  });
+
+  final SignUpPayload? signUp;
+  final String? otpCode;
+  final ProfileInfo? profile;
+  final String? password;
+  final String? pin;
+
+  OnboardingFormData copyWith({
+    SignUpPayload? signUp,
+    String? otpCode,
+    ProfileInfo? profile,
+    String? password,
+    String? pin,
+  }) {
+    return OnboardingFormData(
+      signUp: signUp ?? this.signUp,
+      otpCode: otpCode ?? this.otpCode,
+      profile: profile ?? this.profile,
+      password: password ?? this.password,
+      pin: pin ?? this.pin,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      ...?signUp?.toJson(),
+      if (otpCode != null) 'otp_code': otpCode,
+      ...?profile?.toJson(),
+      if (password != null) 'password': password,
+      if (pin != null) 'pin': pin,
+    };
+  }
+
+  @override
+  List<Object?> get props => [signUp, otpCode, profile, password, pin];
+}

--- a/lib/features/Onboarding/providers/onboarding_controller.dart
+++ b/lib/features/Onboarding/providers/onboarding_controller.dart
@@ -166,3 +166,13 @@ class OnboardingController extends StateNotifier<OnboardingState> {
     }
   }
 }
+
+String onboardingErrorMessage(Object error) {
+  if (error is OnboardingException) {
+    return error.message;
+  }
+  if (error is StateError) {
+    return error.message;
+  }
+  return error.toString();
+}

--- a/lib/features/Onboarding/providers/onboarding_controller.dart
+++ b/lib/features/Onboarding/providers/onboarding_controller.dart
@@ -1,0 +1,168 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/onboarding_repository.dart';
+import '../domain/onboarding_models.dart';
+
+final onboardingRepositoryProvider =
+    Provider<OnboardingRepository>((_) => MockOnboardingRepository());
+
+final onboardingControllerProvider =
+    StateNotifierProvider<OnboardingController, OnboardingState>((ref) {
+  return OnboardingController(ref.watch(onboardingRepositoryProvider));
+});
+
+class OnboardingState extends Equatable {
+  const OnboardingState({
+    required this.data,
+    required this.status,
+  });
+
+  factory OnboardingState.initial() =>
+      const OnboardingState(data: OnboardingFormData(), status: AsyncData(null));
+
+  final OnboardingFormData data;
+  final AsyncValue<void> status;
+
+  OnboardingState copyWith({
+    OnboardingFormData? data,
+    AsyncValue<void>? status,
+  }) {
+    return OnboardingState(
+      data: data ?? this.data,
+      status: status ?? this.status,
+    );
+  }
+
+  @override
+  List<Object?> get props => [data, status];
+}
+
+class OnboardingController extends StateNotifier<OnboardingState> {
+  OnboardingController(this._repository) : super(OnboardingState.initial());
+
+  final OnboardingRepository _repository;
+
+  Future<bool> requestOtp(SignUpPayload payload) async {
+    state = state.copyWith(status: const AsyncLoading());
+    try {
+      await _repository.requestOtp(payload);
+      state = state.copyWith(
+        data: state.data.copyWith(signUp: payload),
+        status: const AsyncData(null),
+      );
+      return true;
+    } catch (error, stack) {
+      state = state.copyWith(status: AsyncError(error, stack));
+      return false;
+    }
+  }
+
+  Future<bool> verifyOtp(String otp) async {
+    final signUp = state.data.signUp;
+    if (signUp == null) {
+      state = state.copyWith(
+        status: AsyncError(
+          StateError('Thiếu thông tin đăng ký ban đầu'),
+          StackTrace.current,
+        ),
+      );
+      return false;
+    }
+
+    state = state.copyWith(status: const AsyncLoading());
+    try {
+      await _repository.verifyOtp(phone: signUp.phoneNumber, otp: otp);
+      state = state.copyWith(
+        data: state.data.copyWith(otpCode: otp),
+        status: const AsyncData(null),
+      );
+      return true;
+    } catch (error, stack) {
+      state = state.copyWith(status: AsyncError(error, stack));
+      return false;
+    }
+  }
+
+  Future<bool> submitProfile(ProfileInfo info) async {
+    final signUp = state.data.signUp;
+    if (signUp == null) {
+      state = state.copyWith(
+        status: AsyncError(
+          StateError('Thiếu thông tin đăng ký ban đầu'),
+          StackTrace.current,
+        ),
+      );
+      return false;
+    }
+
+    state = state.copyWith(status: const AsyncLoading());
+    try {
+      await _repository.submitProfile(phone: signUp.phoneNumber, profile: info);
+      state = state.copyWith(
+        data: state.data.copyWith(profile: info),
+        status: const AsyncData(null),
+      );
+      return true;
+    } catch (error, stack) {
+      state = state.copyWith(status: AsyncError(error, stack));
+      return false;
+    }
+  }
+
+  Future<bool> setPassword(String password) async {
+    final signUp = state.data.signUp;
+    if (signUp == null) {
+      state = state.copyWith(
+        status: AsyncError(
+          StateError('Thiếu thông tin đăng ký ban đầu'),
+          StackTrace.current,
+        ),
+      );
+      return false;
+    }
+
+    state = state.copyWith(status: const AsyncLoading());
+    try {
+      await _repository.setPassword(phone: signUp.phoneNumber, password: password);
+      state = state.copyWith(
+        data: state.data.copyWith(password: password),
+        status: const AsyncData(null),
+      );
+      return true;
+    } catch (error, stack) {
+      state = state.copyWith(status: AsyncError(error, stack));
+      return false;
+    }
+  }
+
+  Future<bool> completeRegistration(String pin) async {
+    final currentData = state.data.copyWith(pin: pin);
+    final signUp = currentData.signUp;
+    if (signUp == null) {
+      state = state.copyWith(
+        status: AsyncError(
+          StateError('Thiếu thông tin đăng ký ban đầu'),
+          StackTrace.current,
+        ),
+      );
+      return false;
+    }
+
+    state = state.copyWith(status: const AsyncLoading());
+    try {
+      await _repository.finalize(currentData);
+      state = OnboardingState.initial();
+      return true;
+    } catch (error, stack) {
+      state = state.copyWith(status: AsyncError(error, stack));
+      return false;
+    }
+  }
+
+  void clearStatus() {
+    if (!state.status.isLoading) {
+      state = state.copyWith(status: const AsyncData(null));
+    }
+  }
+}

--- a/lib/features/Onboarding/ui/enter_password.dart
+++ b/lib/features/Onboarding/ui/enter_password.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/set_security_page.dart';
 
@@ -19,22 +18,6 @@ class _PasswordSetupScreenState extends ConsumerState<PasswordSetupScreen> {
   // Trạng thái ẩn/hiện mật khẩu
   bool _obscurePassword = true;
   bool _obscureConfirm = true;
-
-  @override
-  void initState() {
-    super.initState();
-    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
-      next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(message)),
-        );
-        ref.read(onboardingControllerProvider.notifier).clearStatus();
-      });
-    });
-  }
 
   @override
   void dispose() {
@@ -80,6 +63,18 @@ class _PasswordSetupScreenState extends ConsumerState<PasswordSetupScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
+
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(

--- a/lib/features/Onboarding/ui/enter_password.dart
+++ b/lib/features/Onboarding/ui/enter_password.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/set_security_page.dart';
 

--- a/lib/features/Onboarding/ui/enter_password.dart
+++ b/lib/features/Onboarding/ui/enter_password.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/set_security_page.dart';
 
@@ -66,8 +65,7 @@ class _PasswordSetupScreenState extends ConsumerState<PasswordSetupScreen> {
   Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
+        final message = onboardingErrorMessage(error);
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(message)),

--- a/lib/features/Onboarding/ui/enter_password.dart
+++ b/lib/features/Onboarding/ui/enter_password.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
+import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/set_security_page.dart';
-import 'package:time_bank_flutter/features/auth/ui/login_page.dart';
 
-class PasswordSetupScreen extends StatefulWidget {
+class PasswordSetupScreen extends ConsumerStatefulWidget {
   const PasswordSetupScreen({super.key});
 
   @override
-  State<PasswordSetupScreen> createState() => _PasswordSetupScreenState();
+  ConsumerState<PasswordSetupScreen> createState() => _PasswordSetupScreenState();
 }
 
-class _PasswordSetupScreenState extends State<PasswordSetupScreen> {
+class _PasswordSetupScreenState extends ConsumerState<PasswordSetupScreen> {
   final _formKey = GlobalKey<FormState>();
   final _passwordController = TextEditingController();
   final _confirmController = TextEditingController();
@@ -19,20 +21,41 @@ class _PasswordSetupScreenState extends State<PasswordSetupScreen> {
   bool _obscureConfirm = true;
 
   @override
+  void initState() {
+    super.initState();
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
+  }
+
+  @override
   void dispose() {
     _passwordController.dispose();
     _confirmController.dispose();
     super.dispose();
   }
 
-  void _onSubmit() {
-    if (_formKey.currentState!.validate()) {
-      // Nếu hợp lệ → chuyển sang LoginPage
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (context) => const PinSetupScreen()),
-      );
+  Future<void> _onSubmit() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
     }
+
+    final success = await ref
+        .read(onboardingControllerProvider.notifier)
+        .setPassword(_passwordController.text);
+    if (!mounted || !success) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const PinSetupScreen()),
+    );
   }
 
   // Hàm kiểm tra ràng buộc mật khẩu: >=8 ký tự và có chữ hoa
@@ -177,30 +200,45 @@ class _PasswordSetupScreenState extends State<PasswordSetupScreen> {
                         const SizedBox(height: 60),
 
                         // Nút Hoàn tất (gradient xanh)
-                        Container(
-                          width: double.infinity,
-                          height: 48,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(14),
-                            gradient: const LinearGradient(
-                              colors: [Color(0xFF0D1B4C), Color(0xFF0F58A1)],
-                            ),
-                          ),
-                          child: ElevatedButton(
-                            onPressed: _onSubmit,
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.transparent,
-                              shadowColor: Colors.transparent,
-                              foregroundColor: Colors.white,
-                              shape: RoundedRectangleBorder(
+                        Consumer(
+                          builder: (context, ref, _) {
+                            final state =
+                                ref.watch(onboardingControllerProvider);
+                            final isLoading = state.status.isLoading;
+                            return Container(
+                              width: double.infinity,
+                              height: 48,
+                              decoration: BoxDecoration(
                                 borderRadius: BorderRadius.circular(14),
+                                gradient: const LinearGradient(
+                                  colors: [Color(0xFF0D1B4C), Color(0xFF0F58A1)],
+                                ),
                               ),
-                            ),
-                            child: const Text(
-                              "Hoàn tất",
-                              style: TextStyle(fontSize: 16),
-                            ),
-                          ),
+                              child: ElevatedButton(
+                                onPressed: isLoading ? null : _onSubmit,
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: Colors.transparent,
+                                  shadowColor: Colors.transparent,
+                                  foregroundColor: Colors.white,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(14),
+                                  ),
+                                ),
+                                child: isLoading
+                                    ? const SizedBox(
+                                        width: 20,
+                                        height: 20,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                        ),
+                                      )
+                                    : const Text(
+                                        "Hoàn tất",
+                                        style: TextStyle(fontSize: 16),
+                                      ),
+                              ),
+                            );
+                          },
                         ),
                         const SizedBox(height: 12),
 

--- a/lib/features/Onboarding/ui/profile_page.dart
+++ b/lib/features/Onboarding/ui/profile_page.dart
@@ -93,8 +93,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
+        final message = onboardingErrorMessage(error);
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(message)),

--- a/lib/features/Onboarding/ui/profile_page.dart
+++ b/lib/features/Onboarding/ui/profile_page.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
+import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
+import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/enter_password.dart';
-import 'package:time_bank_flutter/features/Onboarding/ui/set_security_page.dart';
 
-class ProfileScreen extends StatefulWidget {
+class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
 
   @override
-  State<ProfileScreen> createState() => _ProfileScreenState();
+  ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
 }
 
-class _ProfileScreenState extends State<ProfileScreen> {
+class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   final _formKey = GlobalKey<FormState>();
   DateTime? selectedDate;
 
@@ -88,7 +91,25 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final state = ref.watch(onboardingControllerProvider);
+    final isLoading = state.status.isLoading;
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(
@@ -231,16 +252,37 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         SizedBox(
                           width: double.infinity,
                           child: ElevatedButton(
-                            onPressed: () {
-                              if (_formKey.currentState!.validate()) {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (_) =>
-                                      const PasswordSetupScreen()),
-                                );
-                              }
-                            },
+                            onPressed: isLoading
+                                ? null
+                                : () async {
+                                    if (!_formKey.currentState!.validate()) {
+                                      return;
+                                    }
+                                    if (selectedDate == null ||
+                                        gender == null ||
+                                        major == null ||
+                                        address == null) {
+                                      return;
+                                    }
+                                    final info = ProfileInfo(
+                                      birthDate: selectedDate!,
+                                      gender: gender!,
+                                      major: major!,
+                                      address: address!,
+                                    );
+                                    final success = await ref
+                                        .read(onboardingControllerProvider
+                                            .notifier)
+                                        .submitProfile(info);
+                                    if (!mounted || !success) return;
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (_) =>
+                                            const PasswordSetupScreen(),
+                                      ),
+                                    );
+                                  },
                             style: ElevatedButton.styleFrom(
                               backgroundColor: const Color(0xFF0D1B4C),
                               foregroundColor: Colors.white,
@@ -249,7 +291,16 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 borderRadius: BorderRadius.circular(12),
                               ),
                             ),
-                            child: const Text("Tiếp theo"),
+                            child: isLoading
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: Colors.white,
+                                    ),
+                                  )
+                                : const Text("Tiếp theo"),
                           ),
                         ),
                         const SizedBox(height: 12),

--- a/lib/features/Onboarding/ui/profile_page.dart
+++ b/lib/features/Onboarding/ui/profile_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
 import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/enter_password.dart';
@@ -91,8 +90,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
   }
 
   @override
-  void initState() {
-    super.initState();
+  Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
         final message =
@@ -104,10 +102,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
         ref.read(onboardingControllerProvider.notifier).clearStatus();
       });
     });
-  }
 
-  @override
-  Widget build(BuildContext context) {
     final state = ref.watch(onboardingControllerProvider);
     final isLoading = state.status.isLoading;
     return Scaffold(

--- a/lib/features/Onboarding/ui/set_security_page.dart
+++ b/lib/features/Onboarding/ui/set_security_page.dart
@@ -1,18 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
-import 'package:time_bank_flutter/features/Onboarding/ui/enter_password.dart';
+import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
+import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/auth/ui/login_page.dart';
 
-class PinSetupScreen extends StatefulWidget {
+class PinSetupScreen extends ConsumerStatefulWidget {
   const PinSetupScreen({super.key});
 
   @override
-  State<PinSetupScreen> createState() => _PinSetupScreenState();
+  ConsumerState<PinSetupScreen> createState() => _PinSetupScreenState();
 }
 
-class _PinSetupScreenState extends State<PinSetupScreen> {
+class _PinSetupScreenState extends ConsumerState<PinSetupScreen> {
   String _pin = "";
   String _confirmPin = "";
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -127,44 +145,67 @@ class _PinSetupScreenState extends State<PinSetupScreen> {
                       const SizedBox(height: 20),
 
                       // Nút Xác Thực
-                      GestureDetector(
-                        onTap: () {
-                          if (_pin == _confirmPin && _pin.length == 6) {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => const LoginPage(),
-                              ),
-                            );
-                          } else {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                backgroundColor: Colors.red,
-                                content: Text(
-                                  "Mã PIN không khớp hoặc chưa đủ 6 số!",
+                      Consumer(
+                        builder: (context, ref, _) {
+                          final state =
+                              ref.watch(onboardingControllerProvider);
+                          final isLoading = state.status.isLoading;
+                          return GestureDetector(
+                            onTap: isLoading
+                                ? null
+                                : () async {
+                                    if (_pin != _confirmPin || _pin.length != 6) {
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        const SnackBar(
+                                          backgroundColor: Colors.red,
+                                          content: Text(
+                                            "Mã PIN không khớp hoặc chưa đủ 6 số!",
+                                          ),
+                                        ),
+                                      );
+                                      return;
+                                    }
+                                    final success = await ref
+                                        .read(onboardingControllerProvider
+                                            .notifier)
+                                        .completeRegistration(_pin);
+                                    if (!mounted || !success) return;
+                                    Navigator.of(context).pushAndRemoveUntil(
+                                      MaterialPageRoute(
+                                          builder: (_) => const LoginPage()),
+                                      (route) => false,
+                                    );
+                                  },
+                            child: Container(
+                              width: double.infinity,
+                              height: 48,
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(12),
+                                gradient: const LinearGradient(
+                                  colors: [Color(0xFF0D1B4C), Color(0xFF0F58A1)],
                                 ),
                               ),
-                            );
-                          }
+                              alignment: Alignment.center,
+                              child: isLoading
+                                  ? const SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: Colors.white,
+                                      ),
+                                    )
+                                  : const Text(
+                                      "Xác Thực",
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 16,
+                                      ),
+                                    ),
+                            ),
+                          );
                         },
-                        child: Container(
-                          width: double.infinity,
-                          height: 48,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(12),
-                            gradient: const LinearGradient(
-                              colors: [Color(0xFF0D1B4C), Color(0xFF0F58A1)],
-                            ),
-                          ),
-                          alignment: Alignment.center,
-                          child: const Text(
-                            "Xác Thực",
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                            ),
-                          ),
-                        ),
                       ),
 
                       const SizedBox(height: 20),

--- a/lib/features/Onboarding/ui/set_security_page.dart
+++ b/lib/features/Onboarding/ui/set_security_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
-import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/auth/ui/login_page.dart';
 
@@ -20,8 +19,7 @@ class _PinSetupScreenState extends ConsumerState<PinSetupScreen> {
   Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
+        final message = onboardingErrorMessage(error);
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(message)),

--- a/lib/features/Onboarding/ui/set_security_page.dart
+++ b/lib/features/Onboarding/ui/set_security_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
+import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/auth/ui/login_page.dart';
 

--- a/lib/features/Onboarding/ui/set_security_page.dart
+++ b/lib/features/Onboarding/ui/set_security_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
-import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/auth/ui/login_page.dart';
 
@@ -17,8 +16,7 @@ class _PinSetupScreenState extends ConsumerState<PinSetupScreen> {
   String _confirmPin = "";
 
   @override
-  void initState() {
-    super.initState();
+  Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
         final message =
@@ -30,10 +28,7 @@ class _PinSetupScreenState extends ConsumerState<PinSetupScreen> {
         ref.read(onboardingControllerProvider.notifier).clearStatus();
       });
     });
-  }
 
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(

--- a/lib/features/Onboarding/ui/signup_page.dart
+++ b/lib/features/Onboarding/ui/signup_page.dart
@@ -1,21 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
+import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
+import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/verify_otp_page.dart';
 import 'package:time_bank_flutter/features/auth/ui/login_page.dart';
 
-class SignUpPage extends StatefulWidget {
+class SignUpPage extends ConsumerStatefulWidget {
   const SignUpPage({super.key});
 
   @override
-  State<SignUpPage> createState() => _SignUpPageState();
+  ConsumerState<SignUpPage> createState() => _SignUpPageState();
 }
 
-class _SignUpPageState extends State<SignUpPage> {
+class _SignUpPageState extends ConsumerState<SignUpPage> {
   final _formKey = GlobalKey<FormState>();
 
   final _cccdController = TextEditingController();
   final _phoneController = TextEditingController();
   final _emailController = TextEditingController();
   final _nameController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
+  }
 
   @override
   void dispose() {
@@ -140,34 +160,15 @@ class _SignUpPageState extends State<SignUpPage> {
                         const SizedBox(height: 32),
 
                         // Nút Tiếp theo gradient
-                        Container(
-                          width: double.infinity,
-                          height: 48,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(12),
-                            gradient: const LinearGradient(
-                              colors: [Color(0xFF0D1B4C), Color(0xFF0F58A1)],
-                            ),
-                          ),
-                          child: ElevatedButton(
-                            onPressed: () {
-                              if (_formKey.currentState!.validate()) {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (_) => const OtpScreen()),
-                                );
-                              }
-                            },
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: Colors.transparent,
-                              shadowColor: Colors.transparent,
-                            ),
-                            child: const Text(
-                              "Tiếp theo",
-                              style:
-                              TextStyle(color: Colors.white, fontSize: 16),
-                            ),
+                        _SubmitButton(
+                          formKey: _formKey,
+                          buildPayload: () => SignUpPayload(
+                            citizenId: _cccdController.text.trim(),
+                            phoneNumber: _phoneController.text.trim(),
+                            email: _emailController.text.trim().isEmpty
+                                ? null
+                                : _emailController.text.trim(),
+                            fullName: _nameController.text.trim(),
                           ),
                         ),
 
@@ -274,6 +275,69 @@ class _SignUpPageState extends State<SignUpPage> {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _SubmitButton extends ConsumerStatefulWidget {
+  const _SubmitButton({
+    required this.formKey,
+    required this.buildPayload,
+  });
+
+  final GlobalKey<FormState> formKey;
+  final SignUpPayload Function() buildPayload;
+
+  @override
+  ConsumerState<_SubmitButton> createState() => _SubmitButtonState();
+}
+
+class _SubmitButtonState extends ConsumerState<_SubmitButton> {
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(onboardingControllerProvider);
+    final isLoading = state.status.isLoading;
+    return Container(
+      width: double.infinity,
+      height: 48,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        gradient: const LinearGradient(
+          colors: [Color(0xFF0D1B4C), Color(0xFF0F58A1)],
+        ),
+      ),
+      child: ElevatedButton(
+        onPressed: isLoading
+            ? null
+            : () async {
+                FocusScope.of(context).unfocus();
+                if (!widget.formKey.currentState!.validate()) {
+                  return;
+                }
+                final success = await ref
+                    .read(onboardingControllerProvider.notifier)
+                    .requestOtp(widget.buildPayload());
+                if (!mounted || !success) return;
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const OtpScreen()),
+                );
+              },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+        ),
+        child: isLoading
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Text(
+                "Tiếp theo",
+                style: TextStyle(color: Colors.white, fontSize: 16),
+              ),
+      ),
     );
   }
 }

--- a/lib/features/Onboarding/ui/signup_page.dart
+++ b/lib/features/Onboarding/ui/signup_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
 import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/verify_otp_page.dart';
@@ -22,8 +21,16 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
   final _nameController = TextEditingController();
 
   @override
-  void initState() {
-    super.initState();
+  void dispose() {
+    _cccdController.dispose();
+    _phoneController.dispose();
+    _emailController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
         final message =
@@ -35,19 +42,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
         ref.read(onboardingControllerProvider.notifier).clearStatus();
       });
     });
-  }
 
-  @override
-  void dispose() {
-    _cccdController.dispose();
-    _phoneController.dispose();
-    _emailController.dispose();
-    _nameController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
         // Nền gradient xanh

--- a/lib/features/Onboarding/ui/signup_page.dart
+++ b/lib/features/Onboarding/ui/signup_page.dart
@@ -33,8 +33,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
   Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
+        final message = onboardingErrorMessage(error);
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(message)),

--- a/lib/features/Onboarding/ui/verify_otp_page.dart
+++ b/lib/features/Onboarding/ui/verify_otp_page.dart
@@ -1,27 +1,40 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
+import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
+import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/profile_page.dart';
 
-class OtpScreen extends StatefulWidget {
+class OtpScreen extends ConsumerStatefulWidget {
   const OtpScreen({super.key});
 
   @override
-  State<OtpScreen> createState() => _OtpScreenState();
+  ConsumerState<OtpScreen> createState() => _OtpScreenState();
 }
 
-class _OtpScreenState extends State<OtpScreen> {
+class _OtpScreenState extends ConsumerState<OtpScreen> {
   int _timeLeft = 20; // thời gian đếm ngược (giây)
   Timer? _timer;
 
   final TextEditingController _otpController = TextEditingController();
-  final String _correctOtp = "123456"; // ví dụ OTP đúng
 
   @override
   void initState() {
     super.initState();
     _startCountdown();
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
   }
 
   void _startCountdown() {
@@ -41,8 +54,8 @@ class _OtpScreenState extends State<OtpScreen> {
     super.dispose();
   }
 
-  void _verifyOtp() {
-    final otp = _otpController.text;
+  Future<void> _verifyOtp() async {
+    final otp = _otpController.text.trim();
 
     if (otp.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -51,14 +64,9 @@ class _OtpScreenState extends State<OtpScreen> {
       return;
     }
 
-    if (otp != _correctOtp) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Mã OTP không đúng")),
-      );
-      return;
-    }
-
-    // Nếu đúng thì sang Profile
+    final success =
+        await ref.read(onboardingControllerProvider.notifier).verifyOtp(otp);
+    if (!mounted || !success) return;
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const ProfileScreen()),
@@ -67,6 +75,9 @@ class _OtpScreenState extends State<OtpScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final state = ref.watch(onboardingControllerProvider);
+    final phone = state.data.signUp?.phoneNumber ?? '';
+    final isLoading = state.status.isLoading;
     return Scaffold(
       body: Container(
         decoration: const BoxDecoration(
@@ -107,10 +118,10 @@ class _OtpScreenState extends State<OtpScreen> {
                         controller: _otpController,
                         length: 6,
                         appContext: context,
-                        onChanged: (value) {},
+                        onChanged: (_) {},
                         keyboardType: TextInputType.number,
                         inputFormatters: [
-                          FilteringTextInputFormatter.digitsOnly, // chỉ nhập số
+                          FilteringTextInputFormatter.digitsOnly,
                         ],
                         autoFocus: true,
                         animationType: AnimationType.fade,
@@ -133,9 +144,10 @@ class _OtpScreenState extends State<OtpScreen> {
                       // Thông báo + Thời gian
                       Column(
                         children: [
-                          const Text(
-                            "Đã gửi mã xác minh đến số điện thoại bạn đăng ký.",
-                            style: TextStyle(fontSize: 14, color: Colors.black87),
+                          Text(
+                            "Đã gửi mã xác minh đến số điện thoại $phone.",
+                            style: const TextStyle(
+                                fontSize: 14, color: Colors.black87),
                             textAlign: TextAlign.center,
                           ),
                           const SizedBox(height: 4),
@@ -154,7 +166,7 @@ class _OtpScreenState extends State<OtpScreen> {
 
                       // Nút Xác Thực
                       GestureDetector(
-                        onTap: _verifyOtp,
+                        onTap: isLoading ? null : _verifyOtp,
                         child: Container(
                           width: double.infinity,
                           height: 48,
@@ -165,13 +177,22 @@ class _OtpScreenState extends State<OtpScreen> {
                             ),
                           ),
                           alignment: Alignment.center,
-                          child: const Text(
-                            "Xác Thực",
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                            ),
-                          ),
+                          child: isLoading
+                              ? const SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
+                              : const Text(
+                                  "Xác Thực",
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 16,
+                                  ),
+                                ),
                         ),
                       ),
                     ],

--- a/lib/features/Onboarding/ui/verify_otp_page.dart
+++ b/lib/features/Onboarding/ui/verify_otp_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
-import 'package:time_bank_flutter/features/Onboarding/data/onboarding_repository.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/profile_page.dart';
 
@@ -24,17 +23,6 @@ class _OtpScreenState extends ConsumerState<OtpScreen> {
   void initState() {
     super.initState();
     _startCountdown();
-    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
-      next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(message)),
-        );
-        ref.read(onboardingControllerProvider.notifier).clearStatus();
-      });
-    });
   }
 
   void _startCountdown() {
@@ -75,6 +63,18 @@ class _OtpScreenState extends ConsumerState<OtpScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
+      next.status.whenOrNull(error: (error, __) {
+        final message =
+            error is OnboardingException ? error.message : error.toString();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+        ref.read(onboardingControllerProvider.notifier).clearStatus();
+      });
+    });
+
     final state = ref.watch(onboardingControllerProvider);
     final phone = state.data.signUp?.phoneNumber ?? '';
     final isLoading = state.status.isLoading;

--- a/lib/features/Onboarding/ui/verify_otp_page.dart
+++ b/lib/features/Onboarding/ui/verify_otp_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
+import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/profile_page.dart';
 

--- a/lib/features/Onboarding/ui/verify_otp_page.dart
+++ b/lib/features/Onboarding/ui/verify_otp_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
-import 'package:time_bank_flutter/features/Onboarding/domain/onboarding_models.dart';
 import 'package:time_bank_flutter/features/Onboarding/providers/onboarding_controller.dart';
 import 'package:time_bank_flutter/features/Onboarding/ui/profile_page.dart';
 
@@ -66,8 +65,7 @@ class _OtpScreenState extends ConsumerState<OtpScreen> {
   Widget build(BuildContext context) {
     ref.listen<OnboardingState>(onboardingControllerProvider, (prev, next) {
       next.status.whenOrNull(error: (error, __) {
-        final message =
-            error is OnboardingException ? error.message : error.toString();
+        final message = onboardingErrorMessage(error);
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(message)),


### PR DESCRIPTION
## Summary
- add onboarding domain models and a mock repository to mirror expected backend endpoints
- introduce a Riverpod onboarding controller to persist collected form data and handle async status and errors
- rework onboarding UI screens to consume the shared controller with validation, loading, and navigation hooks for each step

## Testing
- not run (Flutter CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e373410204832db2491c3c4c1dcf56